### PR TITLE
Ignore onyx.log in new plugin project

### DIFF
--- a/resources/leiningen/new/onyx_plugin/.gitignore
+++ b/resources/leiningen/new/onyx_plugin/.gitignore
@@ -7,3 +7,5 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+
+onyx.log


### PR DESCRIPTION
I considered ignoring *.log but figured this was less invasive and all that is really required.
